### PR TITLE
Addressable changes

### DIFF
--- a/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
+++ b/com.unity.netcode.gameobjects/Components/NetworkRigidbody.cs
@@ -85,7 +85,11 @@ namespace Unity.Netcode.Components
             }
 
             // If you have authority then you are not kinematic
-            m_Rigidbody.isKinematic = !m_IsAuthority;
+            if (!m_IsAuthority)
+            {
+                m_Rigidbody.isKinematic = true;
+            }
+
 
             // Set interpolation of the Rigidbody based on authority
             // With authority: let local transform handle interpolation

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/NetworkConfig.cs
@@ -238,8 +238,8 @@ namespace Unity.Netcode
                 {
                     var sortedDictionary = Prefabs.NetworkPrefabOverrideLinks.OrderBy(x => x.Key);
                     foreach (var sortedEntry in sortedDictionary)
-
                     {
+                        Debug.Log($"[NetworkConfig] - GetConfig - [{sortedEntry.Key}={sortedEntry.Value.Prefab}]");
                         writer.WriteValueSafe(sortedEntry.Key);
                     }
                 }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -414,8 +414,8 @@ namespace Unity.Netcode
             get
             {
                 if (NetworkObject?.NetworkManager != null)
-                {
                     return NetworkObject?.NetworkManager;
+                {
                 }
 
                 return NetworkManager.Singleton;

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkLogScope.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkLogScope.cs
@@ -1,0 +1,103 @@
+﻿using System;
+
+namespace TrollKing.Core
+{
+    public enum NetworkLoggingLevel
+    {
+        Debug,
+        Info,
+        Warn,
+        Error,
+        Exception,
+        None
+    }
+
+    public class NetworkLogScope
+    {
+        private readonly string m_LoggerName;
+        private readonly NetworkLoggingLevel m_Level = NetworkLoggingLevel.Info;
+
+        public NetworkLogScope(string logName, NetworkLoggingLevel logLevel = NetworkLoggingLevel.Info)
+        {
+            m_LoggerName = logName;
+            m_Level = logLevel;
+        }
+
+        public NetworkLoggingLevel GetLevel()
+        {
+            return m_Level;
+        }
+
+        public void Log(Func<string> stringProvider, NetworkLoggingLevel logLevel = NetworkLoggingLevel.Info)
+        {
+            if (logLevel >= m_Level)
+            {
+                string logString = stringProvider.Invoke();
+                DateTime time = DateTime.Now;
+                var shortTime = time.ToString("T");
+
+                switch (logLevel)
+                {
+                    case NetworkLoggingLevel.Debug:
+                        UnityEngine.Debug.Log($"[{shortTime}][DEBUG][{m_LoggerName}] {logString}");
+                        break;
+                    case NetworkLoggingLevel.Info:
+                        UnityEngine.Debug.Log($"[{shortTime}][INFO][{m_LoggerName}] {logString}");
+                        break;
+                    case NetworkLoggingLevel.Warn:
+                        UnityEngine.Debug.LogWarning($"[{shortTime}][WARN][{m_LoggerName}] {logString}");
+                        break;
+                    case NetworkLoggingLevel.Error:
+                        UnityEngine.Debug.LogError($"[{shortTime}][ERROR][{m_LoggerName}] {logString}");
+                        break;
+                    case NetworkLoggingLevel.Exception:
+                        UnityEngine.Debug.LogError($"[{shortTime}][EXCEPTION][{m_LoggerName}] {logString}");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
+                }
+            }
+        }
+
+        public void Debug(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Debug);
+        }
+
+        public void Info(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Info);
+        }
+
+        public void Warning(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Warn);
+        }
+
+        public void LogWarning(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Warn);
+        }
+
+        public void Error(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Error);
+        }
+
+        public void LogError(Func<string> logString)
+        {
+            Log(logString, NetworkLoggingLevel.Error);
+        }
+
+        public void LogException(Exception e)
+        {
+            UnityEngine.Debug.LogException(e);
+        }
+
+        public void LogError(Exception e)
+        {
+            UnityEngine.Debug.LogError($"[{m_LoggerName}] {e}");
+            UnityEngine.Debug.LogException(e);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkLogScope.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkLogScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3b83aae632414713b8843141e3cea71b
+timeCreated: 1695872236

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -1268,7 +1268,7 @@ namespace Unity.Netcode
         }
 
         // Note that this gets also called manually by OnSceneUnloaded and OnApplicationQuit
-        private void OnDestroy()
+        public virtual void OnDestroy()
         {
             ShutdownInternal();
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -810,7 +810,7 @@ namespace Unity.Netcode
             get => MessageManager.FragmentedMessageMaxSize;
         }
 
-        internal void Initialize(bool server)
+        public virtual void Initialize(bool server)
         {
             // Make sure the ServerShutdownState is reset when initializing
             if (server)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -26,6 +26,11 @@ namespace Unity.Netcode
         [SerializeField]
         internal uint GlobalObjectIdHash;
 
+        public uint GetGlobalHash()
+        {
+            return GlobalObjectIdHash;
+        }
+
         /// <summary>
         /// Used to track the source GlobalObjectIdHash value of the associated network prefab.
         /// When an override exists or it is in-scene placed, GlobalObjectIdHash and PrefabGlobalObjectIdHash
@@ -34,7 +39,7 @@ namespace Unity.Netcode
         internal uint PrefabGlobalObjectIdHash;
 
         /// <summary>
-        /// This is the source prefab of an in-scene placed NetworkObject. This is not set for in-scene 
+        /// This is the source prefab of an in-scene placed NetworkObject. This is not set for in-scene
         /// placd NetworkObjects that are not prefab instances, dynamically spawned prefab instances,
         /// or for network prefab assets.
         /// </summary>
@@ -176,8 +181,8 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// This checks to see if this NetworkObject is an in-scene placed prefab instance. If so it will 
-        /// automatically find the source prefab asset's GlobalObjectIdHash value, assign it to 
+        /// This checks to see if this NetworkObject is an in-scene placed prefab instance. If so it will
+        /// automatically find the source prefab asset's GlobalObjectIdHash value, assign it to
         /// InScenePlacedSourceGlobalObjectIdHash and mark this as being in-scene placed.
         /// </summary>
         /// <remarks>

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -1128,8 +1128,9 @@ namespace Unity.Netcode
 
             if (NetworkManager == null || !NetworkManager.IsListening)
             {
-                transform.parent = m_CachedParent;
-                Debug.LogException(new NotListeningException($"{nameof(NetworkManager)} is not listening, start a server or host before reparenting"));
+                // We should just let offline things happen. Acting otherwise is ridiculous
+                // transform.parent = m_CachedParent;
+                // Debug.LogException(new NotListeningException($"{nameof(NetworkManager)} is not listening, start a server or host before reparenting"));
                 return;
             }
 
@@ -1173,8 +1174,9 @@ namespace Unity.Netcode
             {
                 if (!transform.parent.TryGetComponent<NetworkObject>(out var parentObject))
                 {
-                    transform.parent = m_CachedParent;
-                    Debug.LogException(new InvalidParentException($"Invalid parenting, {nameof(NetworkObject)} moved under a non-{nameof(NetworkObject)} parent"));
+                    Debug.LogWarning($"Moving NetworkObject to a non-Networked parent! Might have issues");
+                    // transform.parent = m_CachedParent;
+                    // Debug.LogException(new InvalidParentException($"Invalid parenting, {nameof(NetworkObject)} moved under a non-{nameof(NetworkObject)} parent"));
                     return;
                 }
 

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkUpdateLoop.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkUpdateLoop.cs
@@ -75,12 +75,24 @@ namespace Unity.Netcode
         private static Dictionary<NetworkUpdateStage, INetworkUpdateSystem[]> s_UpdateSystem_Arrays;
         private const int k_UpdateSystem_InitialArrayCapacity = 1024;
 
+        private static NetworkUpdateStage[] _CACHED_ENUM = null;
+
+        public static NetworkUpdateStage[] GetNetworkUpdateStageEnumValues()
+        {
+            if (_CACHED_ENUM == null)
+            {
+                _CACHED_ENUM = (NetworkUpdateStage[])Enum.GetValues(typeof(NetworkUpdateStage));
+            }
+
+            return _CACHED_ENUM;
+        }
+
         static NetworkUpdateLoop()
         {
             s_UpdateSystem_Sets = new Dictionary<NetworkUpdateStage, HashSet<INetworkUpdateSystem>>();
             s_UpdateSystem_Arrays = new Dictionary<NetworkUpdateStage, INetworkUpdateSystem[]>();
 
-            foreach (NetworkUpdateStage updateStage in Enum.GetValues(typeof(NetworkUpdateStage)))
+            foreach (NetworkUpdateStage updateStage in GetNetworkUpdateStageEnumValues())
             {
                 s_UpdateSystem_Sets.Add(updateStage, new HashSet<INetworkUpdateSystem>());
                 s_UpdateSystem_Arrays.Add(updateStage, new INetworkUpdateSystem[k_UpdateSystem_InitialArrayCapacity]);
@@ -93,7 +105,7 @@ namespace Unity.Netcode
         /// <param name="updateSystem">The <see cref="INetworkUpdateSystem"/> implementation to register for all network updates</param>
         public static void RegisterAllNetworkUpdates(this INetworkUpdateSystem updateSystem)
         {
-            foreach (NetworkUpdateStage updateStage in Enum.GetValues(typeof(NetworkUpdateStage)))
+            foreach (NetworkUpdateStage updateStage in GetNetworkUpdateStageEnumValues())
             {
                 RegisterNetworkUpdate(updateSystem, updateStage);
             }
@@ -137,7 +149,7 @@ namespace Unity.Netcode
         /// <param name="updateSystem">The <see cref="INetworkUpdateSystem"/> implementation to deregister from all network updates</param>
         public static void UnregisterAllNetworkUpdates(this INetworkUpdateSystem updateSystem)
         {
-            foreach (NetworkUpdateStage updateStage in Enum.GetValues(typeof(NetworkUpdateStage)))
+            foreach (NetworkUpdateStage updateStage in GetNetworkUpdateStageEnumValues())
             {
                 UnregisterNetworkUpdate(updateSystem, updateStage);
             }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using TrollKing.Core;
 using Unity.Collections;
 using UnityEngine;
 
@@ -11,11 +12,19 @@ namespace Unity.Netcode
     /// </summary>
     public class CustomMessagingManager
     {
+        private static readonly NetworkLogScope Log = new NetworkLogScope(nameof(CustomMessagingManager));
+
         private readonly NetworkManager m_NetworkManager;
 
         internal CustomMessagingManager(NetworkManager networkManager)
         {
+            Log.Info(() => $"Constructor");
             m_NetworkManager = networkManager;
+        }
+
+        ~CustomMessagingManager()
+        {
+            Log.Info(() => $"Deconstructor");
         }
 
         /// <summary>
@@ -32,7 +41,7 @@ namespace Unity.Netcode
 
         internal void InvokeUnnamedMessage(ulong clientId, FastBufferReader reader, int serializedHeaderSize)
         {
-            Debug.Log($"CustomMessageManager::InvokeUnnamedMessage [CUSTOM] {clientId} {reader.Length} {serializedHeaderSize}");
+            // Debug.Log($"CustomMessageManager::InvokeUnnamedMessage [CUSTOM] {clientId} {reader.Length} {serializedHeaderSize}");
 
             if (OnUnnamedMessage != null)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/CustomMessageManager.cs
@@ -32,6 +32,8 @@ namespace Unity.Netcode
 
         internal void InvokeUnnamedMessage(ulong clientId, FastBufferReader reader, int serializedHeaderSize)
         {
+            Debug.Log($"CustomMessageManager::InvokeUnnamedMessage [CUSTOM] {clientId} {reader.Length} {serializedHeaderSize}");
+
             if (OnUnnamedMessage != null)
             {
                 var pos = reader.Position;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/ConnectionRequestMessage.cs
@@ -92,7 +92,7 @@ namespace Unity.Netcode
                 {
                     if (NetworkLog.CurrentLogLevel <= LogLevel.Normal)
                     {
-                        NetworkLog.LogWarning($"{nameof(NetworkConfig)} mismatch. The configuration between the server and client does not match");
+                        NetworkLog.LogWarning($"{nameof(NetworkConfig)} mismatch. IncomingHash=[{ConfigHash}] OurHash=[{networkManager.NetworkConfig.GetConfig()}] The configuration between the server and client does not match");
                     }
 
                     networkManager.DisconnectClient(context.SenderId);

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/CreateObjectMessage.cs
@@ -1,4 +1,6 @@
 using System.Runtime.CompilerServices;
+using UnityEngine;
+
 namespace Unity.Netcode
 {
     internal struct CreateObjectMessage : INetworkMessage
@@ -10,6 +12,7 @@ namespace Unity.Netcode
 
         public void Serialize(FastBufferWriter writer, int targetVersion)
         {
+            // Debug.Log($"CreateObjectMessage Serialize [v={targetVersion}] [H={ObjectInfo.Hash}] [id={ObjectInfo.NetworkObjectId}]");
             ObjectInfo.Serialize(writer);
         }
 
@@ -28,7 +31,7 @@ namespace Unity.Netcode
                 return false;
             }
             m_ReceivedNetworkVariableData = reader;
-
+            // Debug.Log($"CreateObjectMessage Deserialize [v={receivedMessageVersion}] [H={ObjectInfo.Hash}] [id={ObjectInfo.NetworkObjectId}]");
             return true;
         }
 

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
@@ -22,7 +22,7 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
-            Debug.Log($"UnnamedMessage::Handle [CUSTOM] {context.MessageSize}");
+            // Debug.Log($"UnnamedMessage::Handle [CUSTOM] {context.MessageSize}");
             ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeUnnamedMessage(context.SenderId, m_ReceivedData, context.SerializedHeaderSize);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/Messages/UnnamedMessage.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace Unity.Netcode
 {
     internal struct UnnamedMessage : INetworkMessage
@@ -20,6 +22,7 @@ namespace Unity.Netcode
 
         public void Handle(ref NetworkContext context)
         {
+            Debug.Log($"UnnamedMessage::Handle [CUSTOM] {context.MessageSize}");
             ((NetworkManager)context.SystemOwner).CustomMessagingManager.InvokeUnnamedMessage(context.SenderId, m_ReceivedData, context.SerializedHeaderSize);
         }
     }

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -558,6 +558,7 @@ namespace Unity.Netcode
 
         public static void ReceiveMessage<T>(FastBufferReader reader, ref NetworkContext context, NetworkMessageManager manager) where T : INetworkMessage, new()
         {
+            // Debug.Log($"NetworkMessageManager::ReceiveMessage {reader.Length} - {context.SenderId} {context.MessageSize}");
             var message = new T();
             var messageVersion = 0;
             // Special cases because these are the messages that carry the version info - thus the version info isn't
@@ -639,6 +640,8 @@ namespace Unity.Netcode
                 using var tmpSerializer = new FastBufferWriter(NonFragmentedMessageMaxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>(), Allocator.Temp, maxSize - FastBufferWriter.GetWriteSize<NetworkMessageHeader>());
 
                 message.Serialize(tmpSerializer, messageVersion);
+
+                // Debug.Log($"Sending [CUSTOM] message with {delivery} - Size: {tmpSerializer.Position}");
 
                 var size = SendPreSerializedMessage(tmpSerializer, maxSize, ref message, delivery, clientIds, messageVersion);
                 largestSerializedSize = size > largestSerializedSize ? size : largestSerializedSize;

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/NetworkMessageManager.cs
@@ -611,7 +611,7 @@ namespace Unity.Netcode
             }
 
             var largestSerializedSize = 0;
-            var sentMessageVersions = new NativeHashSet<int>(clientIds.Count, Allocator.Temp);
+            var sentMessageVersions = new NativeParallelHashSet<int>(clientIds.Count, Allocator.Temp);
             for (var i = 0; i < clientIds.Count; ++i)
             {
                 var messageVersion = 0;

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/ISceneManagerHandler.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.SceneManagement;
 
 namespace Unity.Netcode
@@ -8,13 +10,13 @@ namespace Unity.Netcode
     /// Used to override the LoadSceneAsync and UnloadSceneAsync methods called
     /// within the NetworkSceneManager.
     /// </summary>
-    internal interface ISceneManagerHandler
+    public interface ISceneManagerHandler
     {
-        AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress);
+        AsyncOperationHandle<SceneInstance> LoadSceneAsync(string sceneAssetKey, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress);
 
-        AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress);
+        AsyncOperationHandle<SceneInstance> UnloadSceneAsync(SceneInstance scene, SceneEventProgress sceneEventProgress);
 
-        void PopulateLoadedScenes(ref Dictionary<int, Scene> scenesLoaded, NetworkManager networkManager = null);
+        void PopulateLoadedScenes(ref Dictionary<int, NetworkSceneManager.SceneData> scenesLoaded, NetworkManager networkManager = null);
         Scene GetSceneFromLoadedScenes(string sceneName, NetworkManager networkManager = null);
 
         bool DoesSceneHaveUnassignedEntry(string sceneName, NetworkManager networkManager = null);

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Unity.Collections;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.Profiling;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.SceneManagement;
 
 
@@ -27,7 +31,7 @@ namespace Unity.Netcode
         /// <item><term><see cref="SceneEventType.Unload"/></term></item>
         /// </list>
         /// </summary>
-        public AsyncOperation AsyncOperation;
+        public AsyncOperationHandle AsyncOperation;
 
         /// <summary>
         /// Will always be set to the current <see cref="Netcode.SceneEventType"/>
@@ -181,7 +185,7 @@ namespace Unity.Netcode
         /// <param name="sceneName">name of the scene being processed</param>
         /// <param name="loadSceneMode">the LoadSceneMode mode for the scene being loaded</param>
         /// <param name="asyncOperation">the associated <see cref="AsyncOperation"/> that can be used for scene loading progress</param>
-        public delegate void OnLoadDelegateHandler(ulong clientId, string sceneName, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation);
+        public delegate void OnLoadDelegateHandler(ulong clientId, string sceneName, LoadSceneMode loadSceneMode, AsyncOperationHandle<SceneInstance> asyncOperation);
 
         /// <summary>
         /// Delegate declaration for the OnUnload event.<br />
@@ -191,7 +195,7 @@ namespace Unity.Netcode
         /// <param name="clientId">the client that is processing this event (the server will receive all of these events for every client and itself)</param>
         /// <param name="sceneName">name of the scene being processed</param>
         /// <param name="asyncOperation">the associated <see cref="AsyncOperation"/> that can be used for scene unloading progress</param>
-        public delegate void OnUnloadDelegateHandler(ulong clientId, string sceneName, AsyncOperation asyncOperation);
+        public delegate void OnUnloadDelegateHandler(ulong clientId, string sceneName, AsyncOperationHandle<SceneInstance> asyncOperation);
 
         /// <summary>
         /// Delegate declaration for the OnSynchronize event.<br />
@@ -394,7 +398,7 @@ namespace Unity.Netcode
         /// <summary>
         /// The SceneManagerHandler implementation
         /// </summary>
-        internal ISceneManagerHandler SceneManagerHandler = new DefaultSceneManagerHandler();
+        public ISceneManagerHandler SceneManagerHandler = new DefaultSceneManagerHandler();
 
         internal readonly Dictionary<Guid, SceneEventProgress> SceneEventProgressTracking = new Dictionary<Guid, SceneEventProgress>();
 
@@ -413,6 +417,17 @@ namespace Unity.Netcode
         /// </summary>
         internal Scene SceneBeingSynchronized;
 
+        public class SceneData
+        {
+            public SceneData(SceneInstance? instance, Scene reference)
+            {
+                SceneReference = reference;
+                SceneInstance = instance;
+            }
+            public Scene SceneReference;
+            public SceneInstance? SceneInstance;
+        }
+
         /// <summary>
         /// Used to track which scenes are currently loaded
         /// We store the scenes as [SceneHandle][Scene] in order to handle the loading and unloading of the same scene additively
@@ -421,7 +436,7 @@ namespace Unity.Netcode
         /// The client links the server scene handle to the client local scene handle upon a scene being loaded
         /// <see cref="GetAndAddNewlyLoadedSceneByName"/>
         /// </summary>
-        internal Dictionary<int, Scene> ScenesLoaded = new Dictionary<int, Scene>();
+        public Dictionary<int, SceneData> ScenesLoaded = new Dictionary<int, SceneData>();
 
         /// <summary>
         /// Since Scene.handle is unique per client, we create a look-up table between the client and server to associate server unique scene
@@ -458,7 +473,7 @@ namespace Unity.Netcode
             // It is "Ok" if this already has an entry
             if (!ScenesLoaded.ContainsKey(clientHandle))
             {
-                ScenesLoaded.Add(clientHandle, localScene);
+                ScenesLoaded.Add(clientHandle, new SceneData(null, localScene));
             }
 
             return true;
@@ -501,16 +516,6 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Hash to build index lookup table
-        /// </summary>
-        internal Dictionary<uint, int> HashToBuildIndex = new Dictionary<uint, int>();
-
-        /// <summary>
-        /// Build index to hash lookup table
-        /// </summary>
-        internal Dictionary<int, uint> BuildIndexToHash = new Dictionary<int, uint>();
-
-        /// <summary>
         /// The Condition: While a scene is asynchronously loaded in single loading scene mode, if any new NetworkObjects are spawned
         /// they need to be moved into the do not destroy temporary scene
         /// When it is set: Just before starting the asynchronous loading call
@@ -525,10 +530,12 @@ namespace Unity.Netcode
         /// </summary>
         internal Dictionary<uint, SceneEventData> SceneEventDataStore;
 
-        internal readonly NetworkManager NetworkManager;
+        internal Dictionary<string, string> ScenePathsBySceneName;
+
+        private NetworkManager NetworkManager { get; }
 
         // Keep track of this scene until the NetworkSceneManager is destroyed.
-        internal Scene DontDestroyOnLoadScene;
+        public Scene DontDestroyOnLoadScene;
 
         /// <summary>
         /// This setting changes how clients handle scene loading when initially synchronizing with the server.<br />
@@ -543,7 +550,7 @@ namespace Unity.Netcode
         /// <see cref="VerifySceneBeforeLoading"/> and, if <see cref="PostSynchronizationSceneUnloading"/> is
         /// set, <see cref="VerifySceneBeforeUnloading"/> callback(s).
         /// </remarks>
-        public LoadSceneMode ClientSynchronizationMode { get; internal set; }
+        public LoadSceneMode ClientSynchronizationMode { get; set; }
 
         /// <summary>
         /// When true, the <see cref="Debug.LogWarning(object)"/> messages will be turned off
@@ -640,104 +647,6 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets the scene name from full path to the scene
-        /// </summary>
-        internal string GetSceneNameFromPath(string scenePath)
-        {
-            var begin = scenePath.LastIndexOf("/", StringComparison.Ordinal) + 1;
-            var end = scenePath.LastIndexOf(".", StringComparison.Ordinal);
-            return scenePath.Substring(begin, end - begin);
-        }
-
-        /// <summary>
-        /// Generates the hash values and associated tables
-        /// for the scenes in build list
-        /// </summary>
-        internal void GenerateScenesInBuild()
-        {
-            // TODO 2023: We could support addressable or asset bundle scenes by
-            // adding a method that would allow users to add scenes to this.
-            // The method would be server-side only and require an additional SceneEventType
-            // that would be used to notify clients of the added scene. This might need
-            // to include information about the addressable or asset bundle (i.e. address to load assets)
-            HashToBuildIndex.Clear();
-            BuildIndexToHash.Clear();
-            for (int i = 0; i < SceneManager.sceneCountInBuildSettings; i++)
-            {
-                var scenePath = SceneUtility.GetScenePathByBuildIndex(i);
-                var hash = XXHash.Hash32(scenePath);
-                var buildIndex = SceneUtility.GetBuildIndexByScenePath(scenePath);
-
-                // In the rare-case scenario where a programmatically generated build has duplicate
-                // scene entries, we will log an error and skip the entry
-                if (!HashToBuildIndex.ContainsKey(hash))
-                {
-                    HashToBuildIndex.Add(hash, buildIndex);
-                    BuildIndexToHash.Add(buildIndex, hash);
-                }
-                else
-                {
-                    Debug.LogError($"{nameof(NetworkSceneManager)} is skipping duplicate scene path entry {scenePath}. Make sure your scenes in build list does not contain duplicates!");
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets the scene name from a hash value generated from the full scene path
-        /// </summary>
-        internal string SceneNameFromHash(uint sceneHash)
-        {
-            // In the event there is no scene associated with the scene event then just return "No Scene"
-            // This can happen during unit tests when clients first connect and the only scene loaded is the
-            // unit test scene (which is ignored by default) that results in a scene event that has no associated
-            // scene.  Under this specific special case, we just return "No Scene".
-            if (sceneHash == 0)
-            {
-                return "No Scene";
-            }
-            return GetSceneNameFromPath(ScenePathFromHash(sceneHash));
-        }
-
-        /// <summary>
-        /// Gets the full scene path from a hash value
-        /// </summary>
-        internal string ScenePathFromHash(uint sceneHash)
-        {
-            if (HashToBuildIndex.ContainsKey(sceneHash))
-            {
-                return SceneUtility.GetScenePathByBuildIndex(HashToBuildIndex[sceneHash]);
-            }
-            else
-            {
-                throw new Exception($"Scene Hash {sceneHash} does not exist in the {nameof(HashToBuildIndex)} table!  Verify that all scenes requiring" +
-                    $" server to client synchronization are in the scenes in build list.");
-            }
-        }
-
-        /// <summary>
-        /// Gets the associated hash value for the scene name or path
-        /// </summary>
-        internal uint SceneHashFromNameOrPath(string sceneNameOrPath)
-        {
-            var buildIndex = SceneUtility.GetBuildIndexByScenePath(sceneNameOrPath);
-            if (buildIndex >= 0)
-            {
-                if (BuildIndexToHash.ContainsKey(buildIndex))
-                {
-                    return BuildIndexToHash[buildIndex];
-                }
-                else
-                {
-                    throw new Exception($"Scene '{sceneNameOrPath}' has a build index of {buildIndex} that does not exist in the {nameof(BuildIndexToHash)} table!");
-                }
-            }
-            else
-            {
-                throw new Exception($"Scene '{sceneNameOrPath}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
-            }
-        }
-
-        /// <summary>
         /// When set to true, this will disable the console warnings about
         /// a scene being invalidated.
         /// </summary>
@@ -776,13 +685,14 @@ namespace Unity.Netcode
             NetworkManager = networkManager;
             SceneEventDataStore = new Dictionary<uint, SceneEventData>();
 
-            // Generates the scene name to hash value
-            GenerateScenesInBuild();
-
             // Since NetworkManager is now always migrated to the DDOL we will use this to get the DDOL scene
             DontDestroyOnLoadScene = networkManager.gameObject.scene;
 
-            // Since the server tracks loaded scenes, we need to add any currently loaded scenes on the 
+            ServerSceneHandleToClientSceneHandle.Add(DontDestroyOnLoadScene.handle, DontDestroyOnLoadScene.handle);
+
+            ScenesLoaded.Add(DontDestroyOnLoadScene.handle, new SceneData(null, DontDestroyOnLoadScene));
+
+            // Since the server tracks loaded scenes, we need to add any currently loaded scenes on the
             // server side when the NetworkManager is started and NetworkSceneManager instantiated when
             // scene management is enabled.
             if (networkManager.IsServer && networkManager.NetworkConfig.EnableSceneManagement)
@@ -790,7 +700,7 @@ namespace Unity.Netcode
                 for (int i = 0; i < SceneManager.sceneCount; i++)
                 {
                     var loadedScene = SceneManager.GetSceneAt(i);
-                    ScenesLoaded.Add(loadedScene.handle, loadedScene);
+                    ScenesLoaded.Add(loadedScene.handle, new SceneData(null, loadedScene));
                 }
                 SceneManagerHandler.PopulateLoadedScenes(ref ScenesLoaded, NetworkManager);
             }
@@ -819,16 +729,12 @@ namespace Unity.Netcode
                 }
             }
 
-            // If the scene's build index is in the hash table
-            if (BuildIndexToHash.ContainsKey(next.buildIndex))
-            {
-                // Notify clients of the change in active scene
-                var sceneEvent = BeginSceneEvent();
-                sceneEvent.SceneEventType = SceneEventType.ActiveSceneChanged;
-                sceneEvent.ActiveSceneHash = BuildIndexToHash[next.buildIndex];
-                SendSceneEventData(sceneEvent.SceneEventId, NetworkManager.ConnectedClientsIds.Where(c => c != NetworkManager.ServerClientId).ToArray());
-                EndSceneEvent(sceneEvent.SceneEventId);
-            }
+            // Notify clients of the change in active scene
+            var sceneEvent = BeginSceneEvent();
+            sceneEvent.SceneEventType = SceneEventType.ActiveSceneChanged;
+            sceneEvent.ActiveSceneAsset = next.name;
+            SendSceneEventData(sceneEvent.SceneEventId, NetworkManager.ConnectedClientsIds.Where(c => c != NetworkManager.ServerClientId).ToArray());
+            EndSceneEvent(sceneEvent.SceneEventId);
         }
 
         /// <summary>
@@ -839,20 +745,10 @@ namespace Unity.Netcode
         /// <param name="sceneIndex">index into ScenesInBuild</param>
         /// <param name="loadSceneMode">LoadSceneMode the scene is going to be loaded</param>
         /// <returns>true (Valid) or false (Invalid)</returns>
-        internal bool ValidateSceneBeforeLoading(uint sceneHash, LoadSceneMode loadSceneMode)
-        {
-            var sceneName = SceneNameFromHash(sceneHash);
-            var sceneIndex = SceneUtility.GetBuildIndexByScenePath(sceneName);
-            return ValidateSceneBeforeLoading(sceneIndex, sceneName, loadSceneMode);
-        }
-
-        /// <summary>
-        /// Overloaded version that is invoked by <see cref="ValidateSceneBeforeLoading"/> and <see cref="SynchronizeNetworkObjects"/>.
-        /// This specifically is to allow runtime generated scenes to be excluded by the server during synchronization.
-        /// </summary>
-        internal bool ValidateSceneBeforeLoading(int sceneIndex, string sceneName, LoadSceneMode loadSceneMode)
+        internal bool ValidateSceneBeforeLoading(string sceneName, LoadSceneMode loadSceneMode)
         {
             var validated = true;
+            var sceneIndex = SceneUtility.GetBuildIndexByScenePath(sceneName);
             if (VerifySceneBeforeLoading != null)
             {
                 validated = VerifySceneBeforeLoading.Invoke(sceneIndex, sceneName, loadSceneMode);
@@ -900,7 +796,7 @@ namespace Unity.Netcode
                     {
                         if (!ScenesLoaded.ContainsKey(sceneLoaded.handle))
                         {
-                            ScenesLoaded.Add(sceneLoaded.handle, sceneLoaded);
+                            ScenesLoaded.Add(sceneLoaded.handle, new SceneData(null, sceneLoaded));
                             SceneManagerHandler.StartTrackingScene(sceneLoaded, true, NetworkManager);
                             return sceneLoaded;
                         }
@@ -934,7 +830,7 @@ namespace Unity.Netcode
                 }
 
                 // Get the scene currently being synchronized
-                SceneBeingSynchronized = ScenesLoaded.ContainsKey(clientSceneHandle) ? ScenesLoaded[clientSceneHandle] : new Scene();
+                SceneBeingSynchronized = ScenesLoaded.ContainsKey(clientSceneHandle) ? ScenesLoaded[clientSceneHandle].SceneReference : new Scene();
 
                 if (!SceneBeingSynchronized.IsValid() || !SceneBeingSynchronized.isLoaded)
                 {
@@ -1006,7 +902,7 @@ namespace Unity.Netcode
             };
             var size = NetworkManager.ConnectionManager.SendMessage(ref message, k_DeliveryType, targetClientIds);
 
-            NetworkManager.NetworkMetrics.TrackSceneEventSent(targetClientIds, (uint)SceneEventDataStore[sceneEventId].SceneEventType, SceneNameFromHash(SceneEventDataStore[sceneEventId].SceneHash), size);
+            NetworkManager.NetworkMetrics.TrackSceneEventSent(targetClientIds, (uint)SceneEventDataStore[sceneEventId].SceneEventType, SceneEventDataStore[sceneEventId].SceneAsset, size);
         }
 
         /// <summary>
@@ -1073,16 +969,53 @@ namespace Unity.Netcode
                 return new SceneEventProgress(null, SceneEventProgressStatus.SceneEventInProgress);
             }
 
-            // Return invalid scene name status if the scene name is invalid
-            if (SceneUtility.GetBuildIndexByScenePath(sceneName) == InvalidSceneNameOrPath)
+            // // Return invalid scene name status if the scene name is invalid
+            // if (SceneUtility.GetBuildIndexByScenePath(sceneName) == InvalidSceneNameOrPath)
+            // {
+            //     Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
+            //     return new SceneEventProgress(null, SceneEventProgressStatus.InvalidSceneName);
+            // }
+            var locatorInfo = Addressables.GetLocatorInfo(sceneName);
+
+            var resourceLocationAsync = Addressables.LoadResourceLocationsAsync(sceneName);
+            resourceLocationAsync.WaitForCompletion();
+            if (resourceLocationAsync.Status == AsyncOperationStatus.Succeeded)
             {
-                Debug.LogError($"Scene '{sceneName}' couldn't be loaded because it has not been added to the build settings scenes in build list.");
-                return new SceneEventProgress(null, SceneEventProgressStatus.InvalidSceneName);
+                if (resourceLocationAsync.Result.Count >= 1)
+                {
+                    var location = resourceLocationAsync.Result[0];
+                    var provider = location.ProviderId;
+                    if (!provider.Contains("Scene"))
+                    {
+                        Debug.LogWarning($"Provider is not a scene provider! {provider}");
+                    }
+
+                    var resourceType = location.ResourceType;
+                    if (resourceType != typeof(SceneInstance))
+                    {
+                        throw new Exception($"Scene is not of the SceneInstance type! {resourceType}");
+                    }
+                    if (location.HasDependencies)
+                    {
+                        // Has dependencies!
+                        // download something?
+                        // no! this is just a verification method
+                    }
+
+                    if (location.PrimaryKey != sceneName)
+                    {
+                        throw new Exception($"Scene is not primary key of the scene name! {location.PrimaryKey} {sceneName}");
+                    }
+                }
+            }
+            else
+            {
+                throw new Exception($"Scene '{sceneName}' couldn't be loaded for its resource location.");
             }
 
             var sceneEventProgress = new SceneEventProgress(NetworkManager)
             {
-                SceneHash = SceneHashFromNameOrPath(sceneName)
+                SceneName = sceneName
             };
 
             SceneEventProgressTracking.Add(sceneEventProgress.Guid, sceneEventProgress);
@@ -1105,7 +1038,7 @@ namespace Unity.Netcode
             var clientsThatCompleted = sceneEventProgress.GetClientsWithStatus(true);
             var clientsThatTimedOut = sceneEventProgress.GetClientsWithStatus(false);
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
-            sceneEventData.SceneHash = sceneEventProgress.SceneHash;
+            sceneEventData.SceneAsset = sceneEventProgress.SceneName;
             sceneEventData.SceneEventType = sceneEventProgress.SceneEventType;
             sceneEventData.ClientsCompleted = clientsThatCompleted;
             sceneEventData.LoadSceneMode = sceneEventProgress.LoadSceneMode;
@@ -1120,14 +1053,14 @@ namespace Unity.Netcode
             NetworkManager.NetworkMetrics.TrackSceneEventSent(
                 NetworkManager.ConnectedClientsIds,
                 (uint)sceneEventProgress.SceneEventType,
-                SceneNameFromHash(sceneEventProgress.SceneHash),
+                sceneEventProgress.SceneName,
                 size);
 
             // Send a local notification to the server that all clients are done loading or unloading
             OnSceneEvent?.Invoke(new SceneEvent()
             {
                 SceneEventType = sceneEventProgress.SceneEventType,
-                SceneName = SceneNameFromHash(sceneEventProgress.SceneHash),
+                SceneName = sceneEventProgress.SceneName,
                 ClientId = NetworkManager.ServerClientId,
                 LoadSceneMode = sceneEventProgress.LoadSceneMode,
                 ClientsThatCompleted = clientsThatCompleted,
@@ -1136,11 +1069,11 @@ namespace Unity.Netcode
 
             if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
             {
-                OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnLoadEventCompleted?.Invoke(sceneEventProgress.SceneName, sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
             else
             {
-                OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventProgress.SceneHash), sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                OnUnloadEventCompleted?.Invoke(sceneEventProgress.SceneName, sceneEventProgress.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
             }
 
             EndSceneEvent(sceneEventData.SceneEventId);
@@ -1186,7 +1119,7 @@ namespace Unity.Netcode
             var sceneEventData = BeginSceneEvent();
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
             sceneEventData.SceneEventType = SceneEventType.Unload;
-            sceneEventData.SceneHash = SceneHashFromNameOrPath(sceneName);
+            sceneEventData.SceneAsset = sceneName;
             sceneEventData.LoadSceneMode = LoadSceneMode.Additive; // The only scenes unloaded are scenes that were additively loaded
             sceneEventData.SceneHandle = sceneHandle;
 
@@ -1196,7 +1129,18 @@ namespace Unity.Netcode
             ScenesLoaded.Remove(scene.handle);
             sceneEventProgress.SceneEventId = sceneEventData.SceneEventId;
             sceneEventProgress.OnSceneEventCompleted = OnSceneUnloaded;
-            var sceneUnload = SceneManagerHandler.UnloadSceneAsync(scene, sceneEventProgress);
+
+            AsyncOperationHandle<SceneInstance> sceneUnload;
+            if (ScenesLoaded[sceneHandle].SceneInstance.HasValue)
+            {
+                sceneUnload = SceneManagerHandler.UnloadSceneAsync(ScenesLoaded[sceneHandle].SceneInstance.Value, sceneEventProgress);
+            }
+            else
+            {
+                throw new Exception("Fuuuuck");
+                sceneUnload = default;
+            }
+
             // Notify local server that a scene is going to be unloaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
@@ -1220,7 +1164,7 @@ namespace Unity.Netcode
         private void OnClientUnloadScene(uint sceneEventId)
         {
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var sceneName = SceneNameFromHash(sceneEventData.SceneHash);
+            var sceneName = sceneEventData.SceneAsset;
 
             if (!ServerSceneHandleToClientSceneHandle.ContainsKey(sceneEventData.SceneHandle))
             {
@@ -1244,7 +1188,7 @@ namespace Unity.Netcode
             // should be migrated temporarily into the DDOL, once the scene is unloaded they will be migrated into the
             // currently active scene.
             var networkManager = NetworkManager;
-            SceneManagerHandler.MoveObjectsFromSceneToDontDestroyOnLoad(ref networkManager, scene);
+            SceneManagerHandler.MoveObjectsFromSceneToDontDestroyOnLoad(ref networkManager, scene.SceneReference);
 
             m_IsSceneEventActive = true;
             var sceneEventProgress = new SceneEventProgress(NetworkManager)
@@ -1252,7 +1196,17 @@ namespace Unity.Netcode
                 SceneEventId = sceneEventData.SceneEventId,
                 OnSceneEventCompleted = OnSceneUnloaded
             };
-            var sceneUnload = SceneManagerHandler.UnloadSceneAsync(scene, sceneEventProgress);
+
+            AsyncOperationHandle<SceneInstance> opHandle;
+            if (ScenesLoaded[sceneHandle].SceneInstance.HasValue)
+            {
+                opHandle = SceneManagerHandler.UnloadSceneAsync(ScenesLoaded[sceneHandle].SceneInstance.Value, sceneEventProgress);
+            }
+            else
+            {
+                throw new Exception("Fuuuuck");
+                opHandle = default;
+            }
 
             SceneManagerHandler.StopTrackingScene(sceneHandle, sceneName, NetworkManager);
 
@@ -1266,21 +1220,21 @@ namespace Unity.Netcode
             // Notify the local client that a scene is going to be unloaded
             OnSceneEvent?.Invoke(new SceneEvent()
             {
-                AsyncOperation = sceneUnload,
+                AsyncOperation = opHandle,
                 SceneEventType = sceneEventData.SceneEventType,
                 LoadSceneMode = LoadSceneMode.Additive,     // The only scenes unloaded are scenes that were additively loaded
                 SceneName = sceneName,
                 ClientId = NetworkManager.LocalClientId   // Server sent this message to the client, but client is executing it
             });
 
-            OnUnload?.Invoke(NetworkManager.LocalClientId, sceneName, sceneUnload);
+            OnUnload?.Invoke(NetworkManager.LocalClientId, sceneName, opHandle);
         }
 
         /// <summary>
         /// Server and Client:
         /// Invoked when an additively loaded scene is unloaded
         /// </summary>
-        private void OnSceneUnloaded(uint sceneEventId)
+        private void OnSceneUnloaded(uint sceneEventId, string sceneName)
         {
             // If we are shutdown or about to shutdown, then ignore this event
             if (!NetworkManager.IsListening || NetworkManager.ShutdownInProgress)
@@ -1315,11 +1269,11 @@ namespace Unity.Netcode
             {
                 SceneEventType = sceneEventData.SceneEventType,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                SceneName = sceneEventData.SceneAsset,
                 ClientId = NetworkManager.IsServer ? NetworkManager.ServerClientId : NetworkManager.LocalClientId
             });
 
-            OnUnloadComplete?.Invoke(NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash));
+            OnUnloadComplete?.Invoke(NetworkManager.LocalClientId, sceneEventData.SceneAsset);
 
             // Clients send a notification back to the server they have completed the unload scene event
             if (!NetworkManager.IsServer)
@@ -1332,7 +1286,7 @@ namespace Unity.Netcode
             m_IsSceneEventActive = false;
         }
 
-        private void EmptySceneUnloadedOperation(uint sceneEventId)
+        private void EmptySceneUnloadedOperation(uint sceneEventId, string sceneName)
         {
             // Do nothing (this is a stub call since it is only used to flush all additively loaded scenes)
         }
@@ -1347,39 +1301,57 @@ namespace Unity.Netcode
             var sceneEventData = SceneEventDataStore[sceneEventId];
             // Unload all additive scenes while making sure we don't try to unload the base scene ( loaded in single mode ).
             var currentActiveScene = SceneManager.GetActiveScene();
+
+            Queue<int> removedScenes = new();
+
             foreach (var keyHandleEntry in ScenesLoaded)
             {
                 // Validate the scene as well as ignore the DDOL (which will have a negative buildIndex)
-                if (currentActiveScene.name != keyHandleEntry.Value.name && keyHandleEntry.Value.buildIndex >= 0)
+                if (currentActiveScene.name != keyHandleEntry.Value.SceneReference.name)
                 {
-                    var sceneEventProgress = new SceneEventProgress(NetworkManager)
+                    var sceneEventProgress = new SceneEventProgress(NetworkManager);
+                    sceneEventProgress.SceneEventId = sceneEventId;
+                    sceneEventProgress.OnSceneEventCompleted = EmptySceneUnloadedOperation;
+
+                    if (keyHandleEntry.Value.SceneInstance != null)
                     {
-                        SceneEventId = sceneEventId,
-                        OnSceneEventCompleted = EmptySceneUnloadedOperation
-                    };
-                    var sceneUnload = SceneManagerHandler.UnloadSceneAsync(keyHandleEntry.Value, sceneEventProgress);
-                    SceneUnloadEventHandler.RegisterScene(this, keyHandleEntry.Value, LoadSceneMode.Additive, sceneUnload);
+                        var sceneUnload = SceneManagerHandler.UnloadSceneAsync(keyHandleEntry.Value.SceneInstance.Value, sceneEventProgress);
+
+                        SceneUnloadEventHandler.RegisterScene(this, keyHandleEntry.Value.SceneReference, LoadSceneMode.Additive, sceneUnload);
+                        removedScenes.Enqueue(keyHandleEntry.Key);
+                    }
                 }
             }
             // clear out our scenes loaded list
-            ScenesLoaded.Clear();
+            while (removedScenes.Count > 0)
+            {
+                var cur = removedScenes.Dequeue();
+                ScenesLoaded.Remove(cur);
+            }
             SceneManagerHandler.ClearSceneTracking(NetworkManager);
         }
 
-        /// <summary>
-        /// <b>Server side:</b>
-        /// Loads the scene name in either additive or single loading mode.
-        /// When applicable, the <see cref="AsyncOperation"/> is delivered within the <see cref="SceneEvent"/> via <see cref="OnSceneEvent"/>
-        /// </summary>
-        /// <param name="sceneName">the name of the scene to be loaded</param>
-        /// <param name="loadSceneMode">how the scene will be loaded (single or additive mode)</param>
-        /// <returns><see cref="SceneEventProgressStatus"/> (<see cref="SceneEventProgressStatus.Started"/> means it was successful)</returns>
-        public SceneEventProgressStatus LoadScene(string sceneName, LoadSceneMode loadSceneMode)
+        public SceneEventProgress LoadAddressableScene(AssetReference sceneReference, LoadSceneMode loadSceneMode)
         {
+            var resourceAsync = Addressables.LoadResourceLocationsAsync(sceneReference);
+            resourceAsync.WaitForCompletion();
+
+            var sceneName = "";
+
+            if (resourceAsync.Status == AsyncOperationStatus.Succeeded)
+            {
+                var sceneKey = resourceAsync.Result[0].PrimaryKey;
+                sceneName = sceneKey;
+            }
+            else
+            {
+                throw new Exception($"Failed to load scene from resource {resourceAsync.OperationException}");
+            }
+
             var sceneEventProgress = ValidateSceneEventLoading(sceneName);
             if (sceneEventProgress.Status != SceneEventProgressStatus.Started)
             {
-                return sceneEventProgress.Status;
+                return sceneEventProgress;
             }
 
             // This will be the message we send to everyone when this scene event sceneEventProgress is complete
@@ -1391,15 +1363,88 @@ namespace Unity.Netcode
             // Now set up the current scene event
             sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
             sceneEventData.SceneEventType = SceneEventType.Load;
-            sceneEventData.SceneHash = SceneHashFromNameOrPath(sceneName);
+            sceneEventData.SceneAsset = sceneName;
             sceneEventData.LoadSceneMode = loadSceneMode;
             var sceneEventId = sceneEventData.SceneEventId;
             // This both checks to make sure the scene is valid and if not resets the active scene event
-            m_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneHash, loadSceneMode);
+            m_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneAsset, loadSceneMode);
             if (!m_IsSceneEventActive)
             {
                 EndSceneEvent(sceneEventId);
-                return SceneEventProgressStatus.SceneFailedVerification;
+                sceneEventProgress.Status = SceneEventProgressStatus.SceneFailedVerification;
+                return sceneEventProgress;
+            }
+
+            if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
+            {
+                // Destroy current scene objects before switching.
+                NetworkManager.SpawnManager.ServerDestroySpawnedSceneObjects();
+
+                // Preserve the objects that should not be destroyed during the scene event
+                MoveObjectsToDontDestroyOnLoad();
+
+                // Now Unload all currently additively loaded scenes
+                UnloadAdditivelyLoadedScenes(sceneEventId);
+
+                // Register the active scene for unload scene event notifications
+                SceneUnloadEventHandler.RegisterScene(this, SceneManager.GetActiveScene(), LoadSceneMode.Single);
+            }
+
+            // Now start loading the scene
+            sceneEventProgress.SceneEventId = sceneEventId;
+            sceneEventProgress.OnSceneEventCompleted = OnSceneLoaded;
+            var sceneLoad = SceneManagerHandler.LoadSceneAsync(sceneName, loadSceneMode, sceneEventProgress);
+
+            // Notify the local server that a scene loading event has begun
+            OnSceneEvent?.Invoke(new SceneEvent()
+            {
+                AsyncOperation = sceneLoad,
+                SceneEventType = sceneEventData.SceneEventType,
+                LoadSceneMode = sceneEventData.LoadSceneMode,
+                SceneName = sceneName,
+                ClientId = NetworkManager.ServerClientId
+            });
+
+            OnLoad?.Invoke(NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
+
+            //Return our scene progress instance
+            return sceneEventProgress;
+        }
+
+        /// <summary>
+        /// <b>Server side:</b>
+        /// Loads the scene name in either additive or single loading mode.
+        /// When applicable, the <see cref="AsyncOperation"/> is delivered within the <see cref="SceneEvent"/> via <see cref="OnSceneEvent"/>
+        /// </summary>
+        /// <param name="sceneName">the name of the scene to be loaded</param>
+        /// <param name="loadSceneMode">how the scene will be loaded (single or additive mode)</param>
+        /// <returns><see cref="SceneEventProgressStatus"/> (<see cref="SceneEventProgressStatus.Started"/> means it was successful)</returns>
+        public SceneEventProgress LoadScene(string sceneName, LoadSceneMode loadSceneMode)
+        {
+            var sceneEventProgress = ValidateSceneEventLoading(sceneName);
+            if (sceneEventProgress.Status != SceneEventProgressStatus.Started)
+            {
+                return sceneEventProgress;
+            }
+
+            // This will be the message we send to everyone when this scene event sceneEventProgress is complete
+            sceneEventProgress.SceneEventType = SceneEventType.LoadEventCompleted;
+            sceneEventProgress.LoadSceneMode = loadSceneMode;
+
+            var sceneEventData = BeginSceneEvent();
+
+            // Now set up the current scene event
+            sceneEventData.SceneEventProgressId = sceneEventProgress.Guid;
+            sceneEventData.SceneEventType = SceneEventType.Load;
+            sceneEventData.SceneAsset = sceneName;
+            sceneEventData.LoadSceneMode = loadSceneMode;
+            var sceneEventId = sceneEventData.SceneEventId;
+            // This both checks to make sure the scene is valid and if not resets the active scene event
+            m_IsSceneEventActive = ValidateSceneBeforeLoading(sceneEventData.SceneAsset, loadSceneMode);
+            if (!m_IsSceneEventActive)
+            {
+                EndSceneEvent(sceneEventId);
+                return new SceneEventProgress(NetworkManager.Singleton, SceneEventProgressStatus.SceneFailedVerification);
             }
 
             if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
@@ -1441,7 +1486,7 @@ namespace Unity.Netcode
             OnLoad?.Invoke(NetworkManager.ServerClientId, sceneName, sceneEventData.LoadSceneMode, sceneLoad);
 
             //Return our scene progress instance
-            return sceneEventProgress.Status;
+            return sceneEventProgress;
         }
 
         /// <summary>
@@ -1452,7 +1497,7 @@ namespace Unity.Netcode
         {
             private static Dictionary<NetworkManager, List<SceneUnloadEventHandler>> s_Instances = new Dictionary<NetworkManager, List<SceneUnloadEventHandler>>();
 
-            internal static void RegisterScene(NetworkSceneManager networkSceneManager, Scene scene, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation = null)
+            internal static void RegisterScene(NetworkSceneManager networkSceneManager, Scene scene, LoadSceneMode loadSceneMode, AsyncOperationHandle asyncOperation = default)
             {
                 var networkManager = networkSceneManager.NetworkManager;
                 if (!s_Instances.ContainsKey(networkManager))
@@ -1497,7 +1542,7 @@ namespace Unity.Netcode
             }
 
             private NetworkSceneManager m_NetworkSceneManager;
-            private AsyncOperation m_AsyncOperation;
+            private AsyncOperationHandle m_AsyncOperation;
             private LoadSceneMode m_LoadSceneMode;
             private ulong m_ClientId;
             private Scene m_Scene;
@@ -1530,7 +1575,7 @@ namespace Unity.Netcode
                 }
             }
 
-            private SceneUnloadEventHandler(NetworkSceneManager networkSceneManager, Scene scene, ulong clientId, LoadSceneMode loadSceneMode, AsyncOperation asyncOperation = null)
+            private SceneUnloadEventHandler(NetworkSceneManager networkSceneManager, Scene scene, ulong clientId, LoadSceneMode loadSceneMode, AsyncOperationHandle asyncOperation = default)
             {
                 m_LoadSceneMode = loadSceneMode;
                 m_AsyncOperation = asyncOperation;
@@ -1548,7 +1593,7 @@ namespace Unity.Netcode
                     ClientId = clientId
                 });
 
-                m_NetworkSceneManager.OnUnload?.Invoke(networkSceneManager.NetworkManager.LocalClientId, m_Scene.name, null);
+                m_NetworkSceneManager.OnUnload?.Invoke(networkSceneManager.NetworkManager.LocalClientId, m_Scene.name, default);
             }
         }
 
@@ -1560,10 +1605,10 @@ namespace Unity.Netcode
         private void OnClientSceneLoadingEvent(uint sceneEventId)
         {
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var sceneName = SceneNameFromHash(sceneEventData.SceneHash);
+            var sceneName = sceneEventData.SceneAsset;
 
             // Run scene validation before loading a scene
-            if (!ValidateSceneBeforeLoading(sceneEventData.SceneHash, sceneEventData.LoadSceneMode))
+            if (!ValidateSceneBeforeLoading(sceneEventData.SceneAsset, sceneEventData.LoadSceneMode))
             {
                 EndSceneEvent(sceneEventId);
                 return;
@@ -1614,7 +1659,7 @@ namespace Unity.Netcode
         /// Client and Server:
         /// Generic on scene loaded callback method to be called upon a scene loading
         /// </summary>
-        private void OnSceneLoaded(uint sceneEventId)
+        private void OnSceneLoaded(uint sceneEventId, string loadedSceneName)
         {
             // If we are shutdown or about to shutdown, then ignore this event
             if (!NetworkManager.IsListening || NetworkManager.ShutdownInProgress)
@@ -1623,11 +1668,12 @@ namespace Unity.Netcode
             }
 
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var nextScene = GetAndAddNewlyLoadedSceneByName(SceneNameFromHash(sceneEventData.SceneHash));
-            if (!nextScene.isLoaded || !nextScene.IsValid())
+            var nextScene = GetAndAddNewlyLoadedSceneByName(loadedSceneName);
+            if (!nextScene.IsValid())
             {
                 throw new Exception($"Failed to find valid scene internal Unity.Netcode for {nameof(GameObject)}s error!");
             }
+            // If we async loaded a single scene, the active will activate it
 
             if (sceneEventData.LoadSceneMode == LoadSceneMode.Single)
             {
@@ -1673,6 +1719,8 @@ namespace Unity.Netcode
         /// </summary>
         private void OnServerLoadedScene(uint sceneEventId, Scene scene)
         {
+            Debug.Log($"NetworkSceneManager - OnServerLoadedScene eventId:{sceneEventId} scene:{scene.name}");
+
             var sceneEventData = SceneEventDataStore[sceneEventId];
             // Register in-scene placed NetworkObjects with spawn manager
             foreach (var keyValuePairByGlobalObjectIdHash in ScenePlacedObjects)
@@ -1727,12 +1775,12 @@ namespace Unity.Netcode
             {
                 SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                SceneName = sceneEventData.SceneAsset,
                 ClientId = NetworkManager.ServerClientId,
                 Scene = scene,
             });
 
-            OnLoadComplete?.Invoke(NetworkManager.ServerClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
+            OnLoadComplete?.Invoke(NetworkManager.ServerClientId, sceneEventData.SceneAsset, sceneEventData.LoadSceneMode);
 
             //Second, only if we are a host do we want register having loaded for the associated SceneEventProgress
             if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId) && NetworkManager.IsHost)
@@ -1763,12 +1811,12 @@ namespace Unity.Netcode
             {
                 SceneEventType = SceneEventType.LoadComplete,
                 LoadSceneMode = sceneEventData.LoadSceneMode,
-                SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                SceneName = sceneEventData.SceneAsset,
                 ClientId = NetworkManager.LocalClientId,
                 Scene = scene,
             });
 
-            OnLoadComplete?.Invoke(NetworkManager.LocalClientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
+            OnLoadComplete?.Invoke(NetworkManager.LocalClientId, sceneEventData.SceneAsset, sceneEventData.LoadSceneMode);
 
             EndSceneEvent(sceneEventId);
         }
@@ -1800,10 +1848,10 @@ namespace Unity.Netcode
             sceneEventData.LoadSceneMode = ClientSynchronizationMode;
             var activeScene = SceneManager.GetActiveScene();
             sceneEventData.SceneEventType = SceneEventType.Synchronize;
-            if (BuildIndexToHash.ContainsKey(activeScene.buildIndex))
-            {
-                sceneEventData.ActiveSceneHash = BuildIndexToHash[activeScene.buildIndex];
-            }
+            // if (BuildIndexToHash.ContainsKey(activeScene.buildIndex))
+            // {
+            //     sceneEventData.ActiveSceneHash = BuildIndexToHash[activeScene.buildIndex];
+            // }
 
             // Organize how (and when) we serialize our NetworkObjects
             for (int i = 0; i < SceneManager.sceneCount; i++)
@@ -1817,6 +1865,7 @@ namespace Unity.Netcode
                     continue;
                 }
 
+                var sceneHash = scene.name;
                 if (scene == DontDestroyOnLoadScene)
                 {
                     continue;
@@ -1826,18 +1875,18 @@ namespace Unity.Netcode
                 // If we are the base scene, then we set the root scene index;
                 if (activeScene == scene)
                 {
-                    if (!ValidateSceneBeforeLoading(scene.buildIndex, scene.name, sceneEventData.LoadSceneMode))
+                    if (!ValidateSceneBeforeLoading(sceneHash, sceneEventData.LoadSceneMode))
                     {
                         continue;
                     }
-                    sceneEventData.SceneHash = SceneHashFromNameOrPath(scene.path);
+                    sceneEventData.SceneAsset = scene.name;
                     sceneEventData.SceneHandle = scene.handle;
                 }
-                else if (!ValidateSceneBeforeLoading(scene.buildIndex, scene.name, LoadSceneMode.Additive))
+                else if (!ValidateSceneBeforeLoading(sceneHash, LoadSceneMode.Additive))
                 {
                     continue;
                 }
-                sceneEventData.AddSceneToSynchronize(SceneHashFromNameOrPath(scene.path), scene.handle);
+                sceneEventData.AddSceneToSynchronize(sceneHash, scene.handle);
             }
 
             sceneEventData.AddSpawnedNetworkObjects();
@@ -1872,17 +1921,17 @@ namespace Unity.Netcode
             var sceneEventData = SceneEventDataStore[sceneEventId];
             var sceneHash = sceneEventData.GetNextSceneSynchronizationHash();
             var sceneHandle = sceneEventData.GetNextSceneSynchronizationHandle();
-            var sceneName = SceneNameFromHash(sceneHash);
+            var sceneName = sceneHash;
             var activeScene = SceneManager.GetActiveScene();
 
-            var loadSceneMode = sceneHash == sceneEventData.SceneHash ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive;
+            var loadSceneMode = sceneHash == sceneEventData.SceneAsset ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive;
 
             // Store the sceneHandle and hash
             sceneEventData.NetworkSceneHandle = sceneHandle;
-            sceneEventData.ClientSceneHash = sceneHash;
+            sceneEventData.SceneAsset = sceneHash;
 
             // If this is the beginning of the synchronization event, then send client a notification that synchronization has begun
-            if (sceneHash == sceneEventData.SceneHash)
+            if (sceneHash == sceneEventData.SceneAsset)
             {
                 OnSceneEvent?.Invoke(new SceneEvent()
                 {
@@ -1904,14 +1953,14 @@ namespace Unity.Netcode
                 return;
             }
 
-            var sceneLoad = (AsyncOperation)null;
+            var sceneLoad = (AsyncOperationHandle<SceneInstance>)default;
 
             // Determines if the client has the scene to be loaded already loaded, if so will return true and the client will skip loading this scene
             // For ClientSynchronizationMode LoadSceneMode.Single, we pass in whether the scene being loaded is the first/primary active scene and if it is already loaded
             // it should pass through to post load processing (ClientLoadedSynchronization).
             // For ClientSynchronizationMode LoadSceneMode.Additive, if the scene is already loaded or the active scene is the scene to be loaded (does not require it to
             // be the initial primary scene) then go ahead and pass through to post load processing (ClientLoadedSynchronization).
-            var shouldPassThrough = SceneManagerHandler.ClientShouldPassThrough(sceneName, sceneHash == sceneEventData.SceneHash, ClientSynchronizationMode, NetworkManager);
+            var shouldPassThrough = SceneManagerHandler.ClientShouldPassThrough(sceneName, sceneName == sceneEventData.SceneAsset, ClientSynchronizationMode, NetworkManager);
 
             if (!shouldPassThrough)
             {
@@ -1938,7 +1987,7 @@ namespace Unity.Netcode
             else
             {
                 // If so, then pass through
-                ClientLoadedSynchronization(sceneEventId);
+                ClientLoadedSynchronization(sceneEventId, sceneName);
             }
         }
 
@@ -1947,10 +1996,9 @@ namespace Unity.Netcode
         /// This handles all of the in-scene and dynamically spawned NetworkObject synchronization
         /// </summary>
         /// <param name="sceneIndex">Netcode scene index that was loaded</param>
-        private void ClientLoadedSynchronization(uint sceneEventId)
+        private void ClientLoadedSynchronization(uint sceneEventId, string sceneName)
         {
             var sceneEventData = SceneEventDataStore[sceneEventId];
-            var sceneName = SceneNameFromHash(sceneEventData.ClientSceneHash);
             var nextScene = SceneManagerHandler.GetSceneFromLoadedScenes(sceneName, NetworkManager);
             if (!nextScene.IsValid())
             {
@@ -1962,7 +2010,7 @@ namespace Unity.Netcode
                 throw new Exception($"Failed to find valid scene internal Unity.Netcode for {nameof(GameObject)}s error!");
             }
 
-            var loadSceneMode = (sceneEventData.ClientSceneHash == sceneEventData.SceneHash ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive);
+            var loadSceneMode = (sceneEventData.ClientSceneName == sceneEventData.SceneAsset ? sceneEventData.LoadSceneMode : LoadSceneMode.Additive);
 
             // For now, during a synchronization event, we will make the first scene the "base/master" scene that denotes a "complete scene switch"
             if (loadSceneMode == LoadSceneMode.Single)
@@ -1984,7 +2032,7 @@ namespace Unity.Netcode
             var responseSceneEventData = BeginSceneEvent();
             responseSceneEventData.LoadSceneMode = loadSceneMode;
             responseSceneEventData.SceneEventType = SceneEventType.LoadComplete;
-            responseSceneEventData.SceneHash = sceneEventData.ClientSceneHash;
+            responseSceneEventData.SceneAsset = sceneEventData.ClientSceneName;
 
 
             var message = new SceneEventMessage
@@ -2038,12 +2086,12 @@ namespace Unity.Netcode
                         if (ScenesLoaded.ContainsKey(networkObject.SceneOriginHandle))
                         {
                             var scene = ScenesLoaded[networkObject.SceneOriginHandle];
-                            if (scene == DontDestroyOnLoadScene)
+                            if (scene.SceneReference == DontDestroyOnLoadScene)
                             {
                                 Debug.Log($"{networkObject.gameObject.name} migrating into DDOL!");
                             }
 
-                            SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene);
+                            SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene.SceneReference);
                         }
                         else if (NetworkManager.LogLevel <= LogLevel.Normal)
                         {
@@ -2067,13 +2115,10 @@ namespace Unity.Netcode
             {
                 case SceneEventType.ActiveSceneChanged:
                     {
-                        if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
+                        var scene = SceneManager.GetSceneByName(sceneEventData.ClientSceneName);
+                        if (scene.isLoaded)
                         {
-                            var scene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
-                            if (scene.isLoaded)
-                            {
-                                SceneManager.SetActiveScene(scene);
-                            }
+                            SceneManager.SetActiveScene(scene);
                         }
                         break;
                     }
@@ -2104,13 +2149,10 @@ namespace Unity.Netcode
                             PopulateScenePlacedObjects(DontDestroyOnLoadScene, false);
 
                             // If needed, set the currently active scene
-                            if (HashToBuildIndex.ContainsKey(sceneEventData.ActiveSceneHash))
+                            var targetActiveScene = SceneManager.GetSceneByName(sceneEventData.ClientSceneName);
+                            if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
                             {
-                                var targetActiveScene = SceneManager.GetSceneByBuildIndex(HashToBuildIndex[sceneEventData.ActiveSceneHash]);
-                                if (targetActiveScene.isLoaded && targetActiveScene.handle != SceneManager.GetActiveScene().handle)
-                                {
-                                    SceneManager.SetActiveScene(targetActiveScene);
-                                }
+                                SceneManager.SetActiveScene(targetActiveScene);
                             }
 
                             // Spawn and Synchronize all NetworkObjects
@@ -2183,7 +2225,7 @@ namespace Unity.Netcode
                         {
                             SceneEventType = sceneEventData.SceneEventType,
                             LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                            SceneName = sceneEventData.SceneAsset,
                             ClientId = NetworkManager.ServerClientId,
                             ClientsThatCompleted = sceneEventData.ClientsCompleted,
                             ClientsThatTimedOut = sceneEventData.ClientsTimedOut,
@@ -2191,11 +2233,11 @@ namespace Unity.Netcode
 
                         if (sceneEventData.SceneEventType == SceneEventType.LoadEventCompleted)
                         {
-                            OnLoadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnLoadEventCompleted?.Invoke(sceneEventData.SceneAsset, sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
                         else
                         {
-                            OnUnloadEventCompleted?.Invoke(SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
+                            OnUnloadEventCompleted?.Invoke(sceneEventData.SceneAsset, sceneEventData.LoadSceneMode, sceneEventData.ClientsCompleted, sceneEventData.ClientsTimedOut);
                         }
 
                         EndSceneEvent(sceneEventId);
@@ -2226,11 +2268,11 @@ namespace Unity.Netcode
                         {
                             SceneEventType = sceneEventData.SceneEventType,
                             LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                            SceneName = sceneEventData.SceneAsset,
                             ClientId = clientId
                         });
 
-                        OnLoadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash), sceneEventData.LoadSceneMode);
+                        OnLoadComplete?.Invoke(clientId, sceneEventData.SceneAsset, sceneEventData.LoadSceneMode);
 
                         if (SceneEventProgressTracking.ContainsKey(sceneEventData.SceneEventProgressId))
                         {
@@ -2250,11 +2292,11 @@ namespace Unity.Netcode
                         {
                             SceneEventType = sceneEventData.SceneEventType,
                             LoadSceneMode = sceneEventData.LoadSceneMode,
-                            SceneName = SceneNameFromHash(sceneEventData.SceneHash),
+                            SceneName = sceneEventData.SceneAsset,
                             ClientId = clientId
                         });
 
-                        OnUnloadComplete?.Invoke(clientId, SceneNameFromHash(sceneEventData.SceneHash));
+                        OnUnloadComplete?.Invoke(clientId, sceneEventData.SceneAsset);
 
                         EndSceneEvent(sceneEventId);
                         break;
@@ -2327,7 +2369,7 @@ namespace Unity.Netcode
                 sceneEventData.Deserialize(reader);
 
                 NetworkManager.NetworkMetrics.TrackSceneEventReceived(
-                   clientId, (uint)sceneEventData.SceneEventType, SceneNameFromHash(sceneEventData.SceneHash), reader.Length);
+                   clientId, (uint)sceneEventData.SceneEventType, sceneEventData.SceneAsset, reader.Length);
 
                 if (sceneEventData.IsSceneEventClientSide())
                 {
@@ -2534,7 +2576,7 @@ namespace Unity.Netcode
         /// or invoked by <see cref="SceneEventData.ProcessDeferredObjectSceneChangedEvents"/> when a client finishes
         /// synchronization.
         /// </summary>
-        internal void MigrateNetworkObjectsIntoScenes()
+        public void MigrateNetworkObjectsIntoScenes()
         {
             try
             {
@@ -2548,7 +2590,7 @@ namespace Unity.Netcode
                             var scene = ScenesLoaded[clientSceneHandle];
                             foreach (var networkObject in sceneEntry.Value)
                             {
-                                SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene);
+                                SceneManager.MoveGameObjectToScene(networkObject.gameObject, scene.SceneReference);
                             }
                         }
                     }

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1411,6 +1411,14 @@ namespace Unity.Netcode
             return sceneEventProgress;
         }
 
+
+        private static Dictionary<string, string> s_ResourceLocationsBySceneName = new();
+
+        public bool PrepareToLoadScene(string sceneName, Action<bool> loaded)
+        {
+            return false;
+        }
+
         /// <summary>
         /// <b>Server side:</b>
         /// Loads the scene name in either additive or single loading mode.
@@ -1421,6 +1429,15 @@ namespace Unity.Netcode
         /// <returns><see cref="SceneEventProgressStatus"/> (<see cref="SceneEventProgressStatus.Started"/> means it was successful)</returns>
         public SceneEventProgress LoadScene(string sceneName, LoadSceneMode loadSceneMode)
         {
+            if (!s_ResourceLocationsBySceneName.TryGetValue(sceneName, out var found))
+            {
+                var resourceLocationAsync = Addressables.LoadResourceLocationsAsync(sceneName);
+                if (!resourceLocationAsync.IsValid())
+                {
+                    return null;
+                }
+            }
+
             var sceneEventProgress = ValidateSceneEventLoading(sceneName);
             if (sceneEventProgress.Status != SceneEventProgressStatus.Started)
             {

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.SceneManagement;
 using AsyncOperation = UnityEngine.AsyncOperation;
 
@@ -61,7 +63,7 @@ namespace Unity.Netcode
     /// Server side only:
     /// This tracks the progress of clients during a load or unload scene event
     /// </summary>
-    internal class SceneEventProgress
+    public class SceneEventProgress
     {
         /// <summary>
         /// List of clientIds of those clients that is done loading the scene.
@@ -77,14 +79,14 @@ namespace Unity.Netcode
         /// <summary>
         /// Delegate type for when the switch scene progress is completed. Either by all clients done loading the scene or by time out.
         /// </summary>
-        internal delegate bool OnCompletedDelegate(SceneEventProgress sceneEventProgress);
+        public delegate bool OnCompletedDelegate(SceneEventProgress sceneEventProgress);
 
         /// <summary>
         /// The callback invoked when the switch scene progress is completed. Either by all clients done loading the scene or by time out.
         /// </summary>
-        internal OnCompletedDelegate OnComplete;
+        public OnCompletedDelegate OnComplete;
 
-        internal Action<uint> OnSceneEventCompleted;
+        public Action<uint, string> OnSceneEventCompleted;
 
         /// <summary>
         /// This will make sure that we only have timed out if we never completed
@@ -97,17 +99,17 @@ namespace Unity.Netcode
         /// <summary>
         /// The hash value generated from the full scene path
         /// </summary>
-        internal uint SceneHash { get; set; }
+        internal string SceneName { get; set; }
 
         internal Guid Guid { get; } = Guid.NewGuid();
         internal uint SceneEventId;
 
         private Coroutine m_TimeOutCoroutine;
-        private AsyncOperation m_AsyncOperation;
+        private AsyncOperationHandle<SceneInstance> m_AsyncOperation;
 
         private NetworkManager m_NetworkManager { get; }
 
-        internal SceneEventProgressStatus Status { get; set; }
+        public SceneEventProgressStatus Status { get; set; }
 
         internal SceneEventType SceneEventType { get; set; }
 
@@ -120,7 +122,7 @@ namespace Unity.Netcode
             {
                 // If we are the host, then add the host-client to the list
                 // of clients that completed if the AsyncOperation is done.
-                if (m_NetworkManager.IsHost && m_AsyncOperation.isDone)
+                if (m_NetworkManager.IsHost && m_AsyncOperation.IsDone)
                 {
                     clients.Add(m_NetworkManager.LocalClientId);
                 }
@@ -139,7 +141,7 @@ namespace Unity.Netcode
                 // If we are the host, then add the host-client to the list
                 // of clients that did not complete if the AsyncOperation is
                 // not done.
-                if (m_NetworkManager.IsHost && !m_AsyncOperation.isDone)
+                if (m_NetworkManager.IsHost && !m_AsyncOperation.IsDone)
                 {
                     clients.Add(m_NetworkManager.LocalClientId);
                 }
@@ -252,22 +254,59 @@ namespace Unity.Netcode
             // Note: Integration tests process scene loading through a queue
             // and the AsyncOperation could not be assigned for several
             // network tick periods. Return false if that is the case.
-            return m_AsyncOperation == null ? false : m_AsyncOperation.isDone;
+
+            // If we're async loading a scene that we tell not to activate, we need to check that the downstream scene has been activated before calling out
+            var initialValid = m_AsyncOperation.IsValid() && m_AsyncOperation.IsDone;
+            if (initialValid)
+            {
+                var res = m_AsyncOperation.Result;
+                return res.Scene.isLoaded;
+            }
+
+            return false;
+        }
+
+        public AsyncOperationHandle<SceneInstance> GetHandle()
+        {
+            return m_AsyncOperation;
         }
 
         /// <summary>
         /// Sets the AsyncOperation for the scene load/unload event
         /// </summary>
-        internal void SetAsyncOperation(AsyncOperation asyncOperation)
+        public void SetAsyncOperation(AsyncOperationHandle<SceneInstance> asyncOperation)
         {
+            // Debug.Log($"[SceneEventProgress] SetAsyncOperation ");
             m_AsyncOperation = asyncOperation;
-            m_AsyncOperation.completed += new Action<AsyncOperation>(asyncOp2 =>
+            m_AsyncOperation.Completed += new Action<AsyncOperationHandle<SceneInstance>>(asyncOp2 =>
             {
                 // Don't invoke the callback if the network session is disconnected
                 // during a SceneEventProgress
-                if (IsNetworkSessionActive())
+                if (asyncOp2.Status == AsyncOperationStatus.Succeeded)
                 {
-                    OnSceneEventCompleted?.Invoke(SceneEventId);
+                    var sceneInstance = asyncOp2.Result;
+                    if (!sceneInstance.Scene.isLoaded)
+                    {
+                        var asyncLoad = sceneInstance.ActivateAsync();
+                        asyncLoad.completed += operation =>
+                        {
+                            if (IsNetworkSessionActive())
+                            {
+                                OnSceneEventCompleted?.Invoke(SceneEventId, asyncOp2.Result.Scene.name);
+                            }
+                        };
+                    }
+                    else
+                    {
+                        if (IsNetworkSessionActive())
+                        {
+                            OnSceneEventCompleted?.Invoke(SceneEventId, asyncOp2.Result.Scene.name);
+                        }
+                    }
+                }
+                else
+                {
+                    Debug.LogError($"Failed to load async scene: {asyncOp2.OperationException}");
                 }
 
                 // Go ahead and try finishing even if the network session is terminated/terminating

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/SceneEventProgress.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.ResourceManagement.ResourceProviders;

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -704,6 +704,7 @@ namespace Unity.Netcode
 
             networkObject.IsPlayerObject = playerObject;
 
+
             SpawnedObjects.Add(networkObject.NetworkObjectId, networkObject);
             SpawnedObjectsList.Add(networkObject);
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TrollKing.Core;
 using UnityEngine;
 
 namespace Unity.Netcode
@@ -10,6 +11,8 @@ namespace Unity.Netcode
     /// </summary>
     public class NetworkSpawnManager
     {
+        private static readonly NetworkLogScope k_Log = new NetworkLogScope(nameof(NetworkSpawnManager));
+
         // Stores the objects that need to be shown at end-of-frame
         internal Dictionary<ulong, List<NetworkObject>> ObjectsToShowToClient = new Dictionary<ulong, List<NetworkObject>>();
 
@@ -414,7 +417,7 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Gets the right NetworkObject prefab instance to spawn. If a handler is registered or there is an override assigned to the 
+        /// Gets the right NetworkObject prefab instance to spawn. If a handler is registered or there is an override assigned to the
         /// passed in globalObjectIdHash value, then that is what will be instantiated, spawned, and returned.
         /// </summary>
         internal NetworkObject GetNetworkObjectToSpawn(uint globalObjectIdHash, ulong ownerId, Vector3 position = default, Quaternion rotation = default, bool isScenePlaced = false)
@@ -446,8 +449,8 @@ namespace Unity.Netcode
                         case NetworkPrefabOverride.Hash:
                         case NetworkPrefabOverride.Prefab:
                             {
-                                // When scene management is disabled and this is an in-scene placed NetworkObject, we want to always use the 
-                                // SourcePrefabToOverride and not any possible prefab override as a user might want to spawn overrides dynamically 
+                                // When scene management is disabled and this is an in-scene placed NetworkObject, we want to always use the
+                                // SourcePrefabToOverride and not any possible prefab override as a user might want to spawn overrides dynamically
                                 // but might want to use the same source network prefab as an in-scene placed NetworkObject.
                                 // (When scene management is enabled, clients don't delete their in-scene placed NetworkObjects prior to dynamically
                                 // spawning them so the original prefab placed is preserved and this is not needed)
@@ -679,6 +682,9 @@ namespace Unity.Netcode
                 return;
             }
 
+            k_Log.Debug(() => $"[NetworkSpawnManager] NetworkPrefab SpawnNetworkObjectLocallyCommon networkObject={networkObject.name} hash={networkObject.GlobalObjectIdHash} prefabHash={networkObject.PrefabIdHash}, networkId={networkId}, sceneObject={sceneObject}, playerObject={playerObject}, ownerClientId={ownerClientId}, destroyWithScene={destroyWithScene}");
+
+
             networkObject.IsSpawned = true;
             networkObject.IsSceneObject = sceneObject;
 
@@ -778,6 +784,8 @@ namespace Unity.Netcode
             {
                 networkObject.PrefabGlobalObjectIdHash = networkObject.InScenePlacedSourceGlobalObjectIdHash;
             }
+
+            k_Log.Debug(() => $"[NetworkSpawnManager] NetworkPrefab SpawnNetworkObjectLocallyCommon networkObject={networkObject.name} hash={networkObject.GlobalObjectIdHash} prefabHash={networkObject.PrefabIdHash}, networkId={networkId}, sceneObject={sceneObject}, playerObject={playerObject}, ownerClientId={ownerClientId}, destroyWithScene={destroyWithScene}");
         }
 
         internal void SendSpawnCallForObject(ulong clientId, NetworkObject networkObject)
@@ -909,7 +917,7 @@ namespace Unity.Netcode
                             }
                         }
 
-                        // If spawned, then despawn and potentially destroy. 
+                        // If spawned, then despawn and potentially destroy.
                         if (networkObjects[i].IsSpawned)
                         {
                             OnDespawnObject(networkObjects[i], shouldDestroy);
@@ -1107,7 +1115,7 @@ namespace Unity.Netcode
         }
 
         /// <summary>
-        /// Updates all spawned <see cref="NetworkObject.Observers"/> for the specified newly connected client 
+        /// Updates all spawned <see cref="NetworkObject.Observers"/> for the specified newly connected client
         /// Note: if the clientId is the server then it is observable to all spawned <see cref="NetworkObject"/>'s
         /// </summary>
         /// <remarks>

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -425,7 +425,7 @@ namespace Unity.Netcode.Transports.UTP
 
         internal static event Action<int, NetworkDriver> TransportInitialized;
         internal static event Action<int> TransportDisposed;
-        internal NetworkDriver NetworkDriver => m_Driver;
+        public NetworkDriver NetworkDriver => m_Driver;
 
         private PacketLossCache m_PacketLossCache = new PacketLossCache();
 

--- a/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/Runtime/com.unity.netcode.runtime.asmdef
@@ -13,7 +13,9 @@
         "Unity.Networking.Transport",
         "Unity.Collections",
         "Unity.Burst",
-        "Unity.Mathematics"
+        "Unity.Mathematics",
+        "Unity.ResourceManager",
+        "Unity.Addressables"
     ],
     "allowUnsafeCode": true,
     "versionDefines": [

--- a/com.unity.netcode.gameobjects/Samples/Bootstrap/Prefabs/BootstrapPlayer.prefab
+++ b/com.unity.netcode.gameobjects/Samples/Bootstrap/Prefabs/BootstrapPlayer.prefab
@@ -29,12 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3439633038736912633}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3439633038736913157
 MeshFilter:
@@ -55,11 +56,15 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -93,9 +98,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3439633038736912633}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &3439633038736912634
@@ -110,8 +123,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 951099334
+  GlobalObjectIdHash: 2131729030
   AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
 --- !u!114 &2776227185612554462
@@ -138,9 +155,12 @@ MonoBehaviour:
   PositionThreshold: 0
   RotAngleThreshold: 0
   ScaleThreshold: 0
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
   InLocalSpace: 0
   Interpolate: 1
-  FixedSendsPerSecond: 30
+  SlerpPosition: 0
 --- !u!114 &6046305264893698362
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -3,6 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
@@ -57,7 +60,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
             public JobTypes JobType;
             public string SceneName;
-            public Scene Scene;
+            public SceneInstance Scene;
             public SceneEventProgress SceneEventProgress;
             public IntegrationTestSceneHandler IntegrationTestSceneHandler;
         }
@@ -116,7 +119,8 @@ namespace Unity.Netcode.TestHelpers.Runtime
 
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             // We always load additively for all scenes during integration tests
-            var asyncOperation = SceneManager.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
+            var asyncOperation = Addressables.LoadSceneAsync(queuedSceneJob.SceneName, LoadSceneMode.Additive);
+
             queuedSceneJob.SceneEventProgress.SetAsyncOperation(asyncOperation);
 
             // Wait for it to finish
@@ -206,9 +210,9 @@ namespace Unity.Netcode.TestHelpers.Runtime
             }
 
             SceneManager.sceneUnloaded += SceneManager_sceneUnloaded;
-            if (queuedSceneJob.Scene.IsValid() && queuedSceneJob.Scene.isLoaded && !queuedSceneJob.Scene.name.Contains(NetcodeIntegrationTestHelpers.FirstPartOfTestRunnerSceneName))
+            if (queuedSceneJob.Scene.Scene.IsValid() && queuedSceneJob.Scene.Scene.isLoaded && !queuedSceneJob.Scene.Scene.name.Contains(NetcodeIntegrationTestHelpers.FirstPartOfTestRunnerSceneName))
             {
-                var asyncOperation = SceneManager.UnloadSceneAsync(queuedSceneJob.Scene);
+                var asyncOperation = Addressables.UnloadSceneAsync(queuedSceneJob.Scene);
                 queuedSceneJob.SceneEventProgress.SetAsyncOperation(asyncOperation);
             }
             else
@@ -228,7 +232,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         private static void SceneManager_sceneUnloaded(Scene scene)
         {
-            if (CurrentQueuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed && CurrentQueuedSceneJob.Scene.name == scene.name)
+            if (CurrentQueuedSceneJob.JobType != QueuedSceneJob.JobTypes.Completed && CurrentQueuedSceneJob.Scene.Scene.name == scene.name)
             {
                 SceneManager.sceneUnloaded -= SceneManager_sceneUnloaded;
 
@@ -278,14 +282,14 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Server always loads like it normally would
         /// </summary>
-        public AsyncOperation GenericLoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
+        public AsyncOperationHandle<SceneInstance> GenericLoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
         {
             m_ServerSceneBeingLoaded = sceneName;
             if (NetcodeIntegrationTest.IsRunning)
             {
                 SceneManager.sceneLoaded += Sever_SceneLoaded;
             }
-            var operation = SceneManager.LoadSceneAsync(sceneName, loadSceneMode);
+            var operation = Addressables.LoadSceneAsync(sceneName, loadSceneMode);
             sceneEventProgress.SetAsyncOperation(operation);
             return operation;
         }
@@ -302,30 +306,30 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <summary>
         /// Server always unloads like it normally would
         /// </summary>
-        public AsyncOperation GenericUnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
+        public AsyncOperationHandle<SceneInstance> GenericUnloadSceneAsync(SceneInstance scene, SceneEventProgress sceneEventProgress)
         {
-            var operation = SceneManager.UnloadSceneAsync(scene);
+            var operation = Addressables.UnloadSceneAsync(scene);
             sceneEventProgress.SetAsyncOperation(operation);
             return operation;
         }
 
 
-        public AsyncOperation LoadSceneAsync(string sceneName, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
+        public AsyncOperationHandle<SceneInstance> LoadSceneAsync(string sceneAssetKey, LoadSceneMode loadSceneMode, SceneEventProgress sceneEventProgress)
         {
             // Server and non NetcodeIntegrationTest tests use the generic load scene method
             if (!NetcodeIntegrationTest.IsRunning)
             {
-                return GenericLoadSceneAsync(sceneName, loadSceneMode, sceneEventProgress);
+                return GenericLoadSceneAsync(sceneAssetKey, loadSceneMode, sceneEventProgress);
             }
             else // NetcodeIntegrationTest Clients always get added to the jobs queue
             {
-                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneName, SceneEventProgress = sceneEventProgress, JobType = QueuedSceneJob.JobTypes.Loading });
+                AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, SceneName = sceneAssetKey, SceneEventProgress = sceneEventProgress, JobType = QueuedSceneJob.JobTypes.Loading });
             }
 
-            return null;
+            return default;
         }
 
-        public AsyncOperation UnloadSceneAsync(Scene scene, SceneEventProgress sceneEventProgress)
+        public AsyncOperationHandle<SceneInstance> UnloadSceneAsync(SceneInstance scene, SceneEventProgress sceneEventProgress)
         {
             // Server and non NetcodeIntegrationTest tests use the generic unload scene method
             if (!NetcodeIntegrationTest.IsRunning)
@@ -337,7 +341,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 AddJobToQueue(new QueuedSceneJob() { IntegrationTestSceneHandler = this, Scene = scene, SceneEventProgress = sceneEventProgress, JobType = QueuedSceneJob.JobTypes.Unloading });
             }
             // This is OK to return a "nothing" AsyncOperation since we are simulating client loading
-            return null;
+            return default;
         }
 
         /// <summary>
@@ -379,7 +383,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                         {
                             continue;
                         }
-                        NetworkManager.SceneManager.ScenesLoaded.Add(sceneLoaded.handle, sceneLoaded);
+                        NetworkManager.SceneManager.ScenesLoaded.Add(sceneLoaded.handle, new NetworkSceneManager.SceneData(null, sceneLoaded));
                         StartTrackingScene(sceneLoaded, true, NetworkManager);
                         return sceneLoaded;
                     }
@@ -592,7 +596,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
             return m_InvalidScene;
         }
 
-        public void PopulateLoadedScenes(ref Dictionary<int, Scene> scenesLoaded, NetworkManager networkManager)
+        public void PopulateLoadedScenes(ref Dictionary<int, NetworkSceneManager.SceneData> scenesLoaded, NetworkManager networkManager)
         {
             if (!SceneNameToSceneHandles.ContainsKey(networkManager))
             {
@@ -630,7 +634,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     SceneNameToSceneHandles[networkManager][scene.name].Add(scene.handle, sceneEntry);
                     if (!scenesLoaded.ContainsKey(scene.handle))
                     {
-                        scenesLoaded.Add(scene.handle, scene);
+                        scenesLoaded.Add(scene.handle, new NetworkSceneManager.SceneData(null, scene));
                     }
                 }
                 else
@@ -858,7 +862,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     if (!sceneManager.ScenesLoaded.ContainsKey(scene.handle))
                     {
                         StartTrackingScene(scene, true, networkManager);
-                        sceneManager.ScenesLoaded.Add(scene.handle, scene);
+                        sceneManager.ScenesLoaded.Add(scene.handle, new NetworkSceneManager.SceneData(null, scene));
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/IntegrationTestSceneHandler.cs
@@ -290,7 +290,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 SceneManager.sceneLoaded += Sever_SceneLoaded;
             }
             var operation = Addressables.LoadSceneAsync(sceneName, loadSceneMode);
-            sceneEventProgress.SetAsyncOperation(operation);
+            // sceneEventProgress.SetAsyncOperation(operation);
             return operation;
         }
 

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/NetcodeIntegrationTestHelpers.cs
@@ -408,7 +408,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 // with the clients.
                 if (!networkManager.SceneManager.ScenesLoaded.ContainsKey(scene.handle))
                 {
-                    networkManager.SceneManager.ScenesLoaded.Add(scene.handle, scene);
+                    networkManager.SceneManager.ScenesLoaded.Add(scene.handle, new NetworkSceneManager.SceneData(null, scene));
                 }
                 networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
             }

--- a/com.unity.netcode.gameobjects/TestHelpers/Runtime/com.unity.netcode.testhelpers.runtime.asmdef
+++ b/com.unity.netcode.gameobjects/TestHelpers/Runtime/com.unity.netcode.testhelpers.runtime.asmdef
@@ -6,7 +6,9 @@
         "Unity.Multiplayer.MetricTypes",
         "Unity.Multiplayer.NetStats",
         "Unity.Multiplayer.Tools.MetricTypes",
-        "Unity.Multiplayer.Tools.NetStats"
+        "Unity.Multiplayer.Tools.NetStats",
+        "Unity.ResourceManager",
+        "Unity.Addressables"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"


### PR DESCRIPTION
Changes necessary to load addressable scenes with the network scene manager.
Attempting to load a scene must use the same name as the addressable asset id.